### PR TITLE
Fix infinite loop while loading ChErrant M2 file

### DIFF
--- a/cleme/data.py
+++ b/cleme/data.py
@@ -180,10 +180,10 @@ class M2DataReader(DataReader):
                 line_idx += 1
 
             elif line.startswith("T"):  # Target line
+                line_idx += 1
                 if line.endswith("没有错误") or line.endswith("无法标注"):
-                    line_idx += 1
                     LOGGER.debug(f"Unchanged sentence: {src_sent}")
-                if int(line.split("-", 1)[1][1]) != 0:
+                if len(line.split("-", 1)) > 1 and int(line.split("-", 1)[1][1]) != 0:
                     # Only happen on ChERRANT (Chinese). We ignore the follow-up edits.
                     LOGGER.info(f"Ignore repetitive target: {line}")
                     while m2_lines[line_idx].startswith("A "):


### PR DESCRIPTION
When loading a ChErrant M2 file, the program would enter an infinite loop, that it stuck in `while` loop in line 169 of `cleme/data.py`. This is because the `line_idx` will never be incremented if the `line` starts with `T` but does not end with "没有错误" or "无法标注". This PR fixes this issue by moving the `line_idx += 1` outside of the `if` block.

Minor changes:
Add a condition to check if the `line` contains more than 1 item before splitting it, to avoid `ValueError` when the `line` only contains 1 item.
